### PR TITLE
Fix nested closures unserialize error

### DIFF
--- a/lib/ReflectionClosure.php
+++ b/lib/ReflectionClosure.php
@@ -33,7 +33,7 @@ class ReflectionClosure extends ReflectionFunction
         {
             
             $_file_ = $this->getFileName();
-            if (strpos($_file_, ClosureStream::STREAM_PROTO . '://') === 0)
+            if (strpos($_file_, ClosureStream::STREAM_PROTO . '://') === 0 && ($this->getStartLine() === 2))
             {
                 return $this->code = substr($_file_, strlen(ClosureStream::STREAM_PROTO) + 3);
             }

--- a/tests/ClosureTest.php
+++ b/tests/ClosureTest.php
@@ -242,6 +242,28 @@ class ClosureTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(true, $ok);
     }
     
+    public function testClosureNested()
+    {
+        $o = function($a) {
+            
+            // this should never happen
+            if ($a === false) {
+                return false;
+            }
+            
+            $n = function ($b) {
+                return !$b;
+            };
+            $ns = unserialize(serialize(new Opis\Closure\SerializableClosure($n)));
+            
+            return $ns(false);
+        };
+        
+        $os = $this->s($o);
+
+        $this->assertEquals(true, $os(true));
+    }
+    
 }
 
 class A


### PR DESCRIPTION
Added this condition to correctly parse nested closures (test added). It should be equal to 2, to read main closure directly from stream.
