### PR TITLE
Add support for use variable transformations

### DIFF
--- a/src/SerializableClosure.php
+++ b/src/SerializableClosure.php
@@ -143,7 +143,7 @@ class SerializableClosure implements Serializable
 
         $this->scope[$this->closure] = $this;
 
-        $use = $reflector->getUseVariables();
+        $use = $this->transformUseVariables($reflector->getUseVariables());
         $code = $reflector->getCode();
 
         $this->mapByReference($use);
@@ -165,6 +165,17 @@ class SerializableClosure implements Serializable
         }
 
         return $ret;
+    }
+
+    /**
+     * Transform the use variables before serialization.
+     *
+     * @param  array  $data The Closure's use variables
+     * @return array
+     */
+    protected function transformUseVariables($data)
+    {
+        return $data;
     }
 
     /**
@@ -198,6 +209,7 @@ class SerializableClosure implements Serializable
 
         if ($this->code['use']) {
             $this->scope = new ClosureScope();
+            $this->code['use'] = $this->resolveUseVariables($this->code['use']);
             $this->mapPointers($this->code['use']);
             extract($this->code['use'], EXTR_OVERWRITE | EXTR_REFS);
             $this->scope = null;
@@ -220,6 +232,17 @@ class SerializableClosure implements Serializable
         }
 
         $this->code = $this->code['function'];
+    }
+
+    /**
+     * Resolve the use variables after unserialization.
+     *
+     * @param  array  $data The Closure's transformed use variables
+     * @return array
+     */
+    protected function resolveUseVariables($data)
+    {
+        return $data;
     }
 
     /**

--- a/tests/ClosureTest.php
+++ b/tests/ClosureTest.php
@@ -38,6 +38,18 @@ class ClosureTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($u(), $a);
     }
 
+    public function testClosureUseTransformation()
+    {
+        $a = 100;
+
+        $c = unserialize(serialize(new TransformingSerializableClosure(function () use ($a)
+        {
+            return $a;
+        })));
+
+        $this->assertEquals(100, $c());
+    }
+
     public function testClosureUseReturnClosure()
     {
         $a = function($p){
@@ -385,5 +397,27 @@ class A2
 class ObjSelf
 {
     public $o;
+}
+
+
+class TransformingSerializableClosure extends SerializableClosure
+{
+    protected function transformUseVariables($data)
+    {
+        foreach ($data as $key => $value) {
+            $data[$key] = $value * 2;
+        }
+
+        return $data;
+    }
+
+    protected function resolveUseVariables($data)
+    {
+        foreach ($data as $key => $value) {
+            $data[$key] = $value / 2;
+        }
+
+        return $data;
+    }
 }
 


### PR DESCRIPTION
This adds support for transforming and restoring use variables before they are serialized. This may sound like a strange feature, but would allow for some interesting and nice use-cases in Laravel.

For example, when queueing normal classes, Laravel transforms our ORM Eloquent models instance to instances of `ModelIdentifier` which is a simple PHP object that just contains the class and primary key of the model, so we don't have to serialize the entire model with all of its attributes.

Then, on unserializing the job, we restore the `ModelIdentifier` instances back to their normal ORM objects by re-pulling them from the database.

I personally would plan to use this feature by overriding the `transformUseVariables` and `restoreUseVariables` in our own extension of `SerializableClosure` in order to add support for this in Laravel.

**By default, these methods do nothing and there is no change to existing behavior.** This just provides the hook for those that know what they are doing to tap into if they need to.

Let me know what you think!