### PR TITLE
add ability to find traits names in anonymous class

### DIFF
--- a/src/ReflectionClosure.php
+++ b/src/ReflectionClosure.php
@@ -309,6 +309,12 @@ class ReflectionClosure extends ReflectionFunction
                             $state = 'id_start';
                             $lastState = 'closure';
                             break 2;
+                        case T_USE:
+                            $code .= $token[1];
+                            $context = 'use';
+                            $state = 'id_start';
+                            $lastState = 'closure';
+                            break;
                         case T_INSTANCEOF:
                             $code .= $token[1];
                             $context = 'instanceof';
@@ -453,7 +459,12 @@ class ReflectionClosure extends ReflectionFunction
                             break;
                         default:
                             if($id_start !== '\\'){
-                                if($context === 'instanceof' || $context === 'args' || $context === 'return_type' || $context === 'extends'){
+                                if($context === 'use' ||
+                                    $context === 'instanceof' ||
+                                    $context === 'args' ||
+                                    $context === 'return_type' ||
+                                    $context === 'extends'
+                                ){
                                     if($id_start_ci === 'self' || $id_start_ci === 'static' || $id_start_ci === 'parent'){
                                         $isUsingScope = true;
                                     } elseif (!($php7 && in_array($id_start_ci, $php7_types))){

--- a/tests/ReflectionClosure2Test.php
+++ b/tests/ReflectionClosure2Test.php
@@ -112,4 +112,32 @@ class ReflectionClosure2Test extends \PHPUnit\Framework\TestCase
         $this->assertEquals($e2, $this->c($f2));
         $this->assertEquals($e3, $this->c($f3));
     }
+
+    public function testClosureResolveTraitsNamesInAnonymousClasses()
+    {
+        $f1 = function () { new class { use Bar; }; };
+        $e1 = 'function () { new class { use \Foo\Bar; }; }';
+
+        $f2 = function () { new class { use Bar\Test; }; };
+        $e2 = 'function () { new class { use \Foo\Bar\Test; }; }';
+
+        $f3 = function () { new class { use Qux; }; };
+        $e3 = 'function () { new class { use \Foo\Baz; }; }';
+
+        $f4 = function () { new class { use Qux\Test; }; };
+        $e4 = 'function () { new class { use \Foo\Baz\Test; }; }';
+
+        $f5 = function () { new class { use \Foo; }; };
+        $e5 = 'function () { new class { use \Foo; }; }';
+
+        $f6 = function () { new class { use Foo; }; };
+        $e6 = 'function () { new class { use \\' . __NAMESPACE__ . '\Foo; }; }';
+
+        $this->assertEquals($e1, $this->c($f1));
+        $this->assertEquals($e2, $this->c($f2));
+        $this->assertEquals($e3, $this->c($f3));
+        $this->assertEquals($e4, $this->c($f4));
+        $this->assertEquals($e5, $this->c($f5));
+        $this->assertEquals($e6, $this->c($f6));
+    }
 }


### PR DESCRIPTION
This PR fix issue with traits names in anonymous classes inside closures.

How to reproduce:
```php
require __DIR__ . '/vendor/autoload.php';

use Your\Name\Cacheable;
use Opis\Closure\SerializableClosure;

$closure = function () {
    $mock = new class {
        use Cacheable;
    };
};

$wrapper = new SerializableClosure($closure);

$serialized = serialize($wrapper);

$wrapper = unserialize($serialized);

$wrapper();
```