### PR TITLE
fix error with static method called new

### DIFF
--- a/src/ReflectionClosure.php
+++ b/src/ReflectionClosure.php
@@ -365,6 +365,7 @@ class ReflectionClosure extends ReflectionFunction
                     break;
                 case 'ignore_next':
                     switch ($token[0]){
+                        case T_NEW:
                         case T_WHITESPACE:
                             $code .= $token[1];
                             break;

--- a/tests/ReflectionClosure2Test.php
+++ b/tests/ReflectionClosure2Test.php
@@ -146,6 +146,14 @@ class ReflectionClosure2Test extends \PHPUnit\Framework\TestCase
         $this->assertEquals($e7, $this->c($f7));
     }
 
+    public function testStaticMethodNewUsage()
+    {
+        $f1 = function () { Bar::new(); };
+        $e1 = 'function () { \Foo\Bar::new(); }';
+
+        $this->assertEquals($e1, $this->c($f1));
+    }
+
     public function testThisInsideAnonymousClass()
     {
         $f1 = function() {


### PR DESCRIPTION
This PR fix issue with calling static method called "new" inside closures.

How to reproduce:

```php
require __DIR__ . '/vendor/autoload.php';

use Opis\Closure\SerializableClosure;

$closure = function () {
    Bar::new();
};

$wrapper = new SerializableClosure($closure);

$serialized = serialize($wrapper);

$wrapper = unserialize($serialized);

$wrapper();
```