### PR TITLE
Fix Syntax error in ReflectionClosure4Test

### DIFF
--- a/tests/ReflectionClosure4Test.php
+++ b/tests/ReflectionClosure4Test.php
@@ -10,7 +10,7 @@ namespace Opis\Closure\Test;
 use Closure;
 use Opis\Closure\ReflectionClosure;
 use Foo\{
-    Bar as Baz,
+    Bar as Baz
 };
 
 class ReflectionClosure4Test extends \PHPUnit\Framework\TestCase


### PR DESCRIPTION
Fix syntax error `unexpected '}', expecting identifier (T_STRING) or function (T_FUNCTION) or const (T_CONST)` 