### PR TITLE
utf8_encode serialized closure

### DIFF
--- a/src/SerializableClosure.php
+++ b/src/SerializableClosure.php
@@ -147,13 +147,13 @@ class SerializableClosure implements Serializable
 
         $this->mapByReference($use);
 
-        $ret = \serialize(array(
+        $ret = \utf8_encode(\serialize(array(
             'use' => $use,
             'function' => $code,
             'scope' => $scope,
             'this' => $object,
             'self' => $this->reference,
-        ));
+        )));
 
         if(static::$securityProvider !== null){
             $ret =  '@' . json_encode(static::$securityProvider->sign($ret));
@@ -212,7 +212,7 @@ class SerializableClosure implements Serializable
             $data = $data['closure'];
         }
 
-        $this->code = \unserialize($data);
+        $this->code = \unserialize(utf8_decode($data));
 
         // unset data
         unset($data);

--- a/tests/SignedClosureTest.php
+++ b/tests/SignedClosureTest.php
@@ -40,7 +40,8 @@ class SignedClosureTest extends ClosureTest
         $value = serialize(new SerializableClosure($closure));
         $u = unserialize($value);
 
-        $this->assertEquals($a, $u->getClosure()());
+        $c = $u->getClosure();
+        $this->assertEquals($a, $c());
     }
 
     /**

--- a/tests/SignedClosureTest.php
+++ b/tests/SignedClosureTest.php
@@ -27,6 +27,22 @@ class SignedClosureTest extends ClosureTest
         unserialize($value);
     }
 
+    public function testSecureInvalidUtf8Data()
+    {
+        $a = utf8_decode("Düsseldorf");
+        $closure = function() use($a)
+        {
+            return $a;
+        };
+
+        SerializableClosure::setSecretKey('secret');
+
+        $value = serialize(new SerializableClosure($closure));
+        $u = unserialize($value);
+
+        $this->assertEquals($a, $u->getClosure()());
+    }
+
     /**
      * @expectedException \Opis\Closure\SecurityException
      */


### PR DESCRIPTION
Fixes #34. 

To allow malformed UTF-8 characters, I treat the serialized closure as a single-byte ISO 8859-1 string (practically, a byte array) to map any character to a valid UTF-8 datapoint. This enabled `json_encode` to encode the string.

Then, during deserialization, the `json_decode`d output is `utf8_decode` to map it to the original data, regardless of whether it's valid or invalid UTF-8. 

The only real downside of this approach is that original UTF-8 characters at codepoint 0x80 and higher are represented by different characters in the serialized closure... 