### PR TITLE
Update ReflectionClosure.php

### DIFF
--- a/src/ReflectionClosure.php
+++ b/src/ReflectionClosure.php
@@ -615,7 +615,7 @@ class ReflectionClosure extends ReflectionFunction
     protected function getHashedFileName()
     {
         if ($this->hashedName === null) {
-            $this->hashedName = md5($this->getFileName());
+            $this->hashedName = sha1($this->getFileName());
         }
 
         return $this->hashedName;


### PR DESCRIPTION
To resolve a report from Veracode scanning, avoid using md5 for fast-hash. Tests show sha1 is compatible and passes Veracode scans.

https://cwe.mitre.org/data/definitions/327.html

From Veracode:

Attack Vector: !php_standard_ns.md5

Number of Modules Affected: 1

Description: This function uses the !php_standard_ns.md5() function, which uses a hash algorithm that is considered weak. In recent years, researchers have demonstrated ways to breach many uses of previously-thought-safe hash functions such as MD5.

Remediation: Consider using a stronger algorithm in order to prevent attackers from being able to manipulate hash results. If this algorithm is being used to hash passwords, then consider using a strong computationally-hard algorithm such as PBKDF2 or bcrypt instead of a plain hashing algorithm.