### PR TITLE
Fix issue where the code is NOT comming from a file, the code is comm…

### DIFF
--- a/src/ReflectionClosure.php
+++ b/src/ReflectionClosure.php
@@ -628,7 +628,7 @@ class ReflectionClosure extends ReflectionFunction
     {
         if (stripos($this->getFileName(), "eval()'d code") > 0) {
             // In this use case the code is not in a file, it is loaded from the database and eval()'d, so no filename, no tokens.
-            return NULL;
+            return null;
         }
         $key = $this->getHashedFileName();
 
@@ -647,7 +647,7 @@ class ReflectionClosure extends ReflectionFunction
         if ($this->tokens === null) {
             $tokens = $this->getFileTokens();
             if ($tokens === null) {
-              return NULL;
+              return null;
             }
             $startLine = $this->getStartLine();
             $endLine = $this->getEndLine();

--- a/src/ReflectionClosure.php
+++ b/src/ReflectionClosure.php
@@ -626,7 +626,7 @@ class ReflectionClosure extends ReflectionFunction
      */
     protected function getFileTokens()
     {
-        if (stripos($this->getFileName(), "eval()'d code") > 0) {
+        if (stripos($this->getFileName(), "eval()'d code") !== false) {
             // In this use case the code is not in a file, it is loaded from the database and eval()'d, so no filename, no tokens.
             return null;
         }

--- a/src/ReflectionClosure.php
+++ b/src/ReflectionClosure.php
@@ -626,6 +626,10 @@ class ReflectionClosure extends ReflectionFunction
      */
     protected function getFileTokens()
     {
+        if (stripos($this->getFileName(), "eval()'d code") > 0) {
+            // In this use case the code is not in a file, it is loaded from the database and eval()'d, so no filename, no tokens.
+            return NULL;
+        }
         $key = $this->getHashedFileName();
 
         if (!isset(static::$files[$key])) {
@@ -642,6 +646,9 @@ class ReflectionClosure extends ReflectionFunction
     {
         if ($this->tokens === null) {
             $tokens = $this->getFileTokens();
+            if ($tokens === null) {
+              return NULL;
+            }
             $startLine = $this->getStartLine();
             $endLine = $this->getEndLine();
             $results = array();


### PR DESCRIPTION
…ing from the database.

In this use case, php 7.3.x with drupal 7 and the views_php module when using views_bulk_operations.

The php code is comming from the database, not a file, closure library was prior to this commit trying to do a file_get_contents on this string: "path/to/drupal/and/module/path/views_php.module eval()'d code"
of course there is no filename called eval()'d code.

Therefore, this patch is what I cooked up.
see explanation description of this error here:
https://www.drupal.org/comment/13138161#comment-13138161

This commit appears to have resolved these issues. (knock on wood, I am still reviewing).
