### PR TITLE
When the file does not exist, do not process tokens, when there is no tokens do not count null.

### DIFF
--- a/src/ReflectionClosure.php
+++ b/src/ReflectionClosure.php
@@ -116,8 +116,9 @@ class ReflectionClosure extends ReflectionFunction
         $lineAdd = 0;
         $isUsingScope = false;
         $isUsingThisObject = false;
+        $lcnt = ($tokens === null ? 0 : count($tokens));
 
-        for($i = 0, $l = count($tokens); $i < $l; $i++) {
+        for($i = 0, $l = $lcnt; $i < $l; $i++) {
             $token = $tokens[$i];
             switch ($state) {
                 case 'start':

--- a/src/ReflectionClosure.php
+++ b/src/ReflectionClosure.php
@@ -626,6 +626,10 @@ class ReflectionClosure extends ReflectionFunction
      */
     protected function getFileTokens()
     {
+        if (!file_exists($this->getFileName())) {
+            // In this use case the code is not in a file, it is loaded from the database, no tokens.
+            return null;
+        }
         $key = $this->getHashedFileName();
 
         if (!isset(static::$files[$key])) {
@@ -642,6 +646,9 @@ class ReflectionClosure extends ReflectionFunction
     {
         if ($this->tokens === null) {
             $tokens = $this->getFileTokens();
+            if ($tokens === null) {
+              return null;
+            }
             $startLine = $this->getStartLine();
             $endLine = $this->getEndLine();
             $results = array();


### PR DESCRIPTION
Use case: code is comming from the database, not a file.
for a bit of background please see views_php issue:
https://www.drupal.org/project/views_php/issues/2274543

I will sum it up:

The php code is comming from the database, not a file, closure library was prior to this commit trying to do a file_get_contents on this string: "path/to/drupal/and/module/path/views_php.module eval()'d code"
of course there is no filename called eval()'d code.

This ONLY occurs when using views_bulk_operations on views with a field containing views_php enabled code , I'm not sure why.  Normal use cases for views_php seem ok and do not try to load a file that doesn't exist.
