### PR TITLE
Added stream_set_option() so that ClosureStream will work in PHP 7.4

### DIFF
--- a/src/ClosureStream.php
+++ b/src/ClosureStream.php
@@ -41,6 +41,11 @@ class ClosureStream
         return $this->pointer >= $this->length;
     }
 
+    public function stream_set_option($option, $arg1, $arg2)
+    {
+        return false;
+    }
+
     public function stream_stat()
     {
         $stat = stat(__FILE__);


### PR DESCRIPTION
This partially addresses #41 by adding `ClosureStream::stream_set_option()`.  The implementation is as recommended in the [official upgrade guide](https://github.com/php/php-src/blob/php-7.4.0RC5/UPGRADING#L41).