### PR TITLE
Updated branch alias to point to 3.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "3.3.x-dev"
+            "dev-master": "3.4.x-dev"
         }
     }
 }


### PR DESCRIPTION
This makes it possible to pull in the latest changes to `master` without breaking compatibility with packages that require `3.4`.