### PR TITLE
Fixed a bug that caused new'd objects in short closures to not serial…

### DIFF
--- a/src/ReflectionClosure.php
+++ b/src/ReflectionClosure.php
@@ -303,13 +303,13 @@ class ReflectionClosure extends ReflectionFunction
                             break;
                         case ')':
                         case ']':
+                            $code .= $token[0];
                             if ($isShortClosure) {
                                 if ($open === 0) {
                                     break 3;
                                 }
                                 --$open;
                             }
-                            $code .= $token[0];
                             break;
                         case ',':
                         case ';':

--- a/tests/ReflectionClosure5Test.php
+++ b/tests/ReflectionClosure5Test.php
@@ -84,6 +84,13 @@ class ReflectionClosure5Test extends \PHPUnit\Framework\TestCase
         $this->assertEquals($e3, $this->c($f3));
     }
 
+    public function testReturnedObject()
+    {
+        $f = fn() => new \Foo\Bar();
+        $e = 'fn() => new \Foo\Bar();';
+        $this->assertEquals($e, $this->c($f));
+    }
+
     public function testSerialize()
     {
         $f1 = fn() => 'hello';


### PR DESCRIPTION
…ize with the closing constructor parenthesis.  Without this fix, we'd see an error like the following:

```php
ParseError : syntax error, unexpected ';' closure://fn () => new \Foo\Bar(;:2
```