### PR TITLE
Update SerializableClosure.php

### DIFF
--- a/src/SerializableClosure.php
+++ b/src/SerializableClosure.php
@@ -15,7 +15,7 @@ use ReflectionObject;
 /**
  * Provides a wrapper for serialization of closures
  */
-class SerializableClosure implements Serializable
+class SerializableClosure extends Closure implements Serializable
 {
     /**
      * @var Closure Wrapped closure


### PR DESCRIPTION
Fixed error with typed properties
`Typed property Environment\Serializer\CustomSerializer::$serialize must be an instance of Closure, Opis\Closure\SerializableClosure used`