### PR TITLE
Fixed actions setup

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,9 +39,6 @@ jobs:
         env:
           phpts: ${{ matrix.zts }}
 
-      - name: Update composer
-        run: composer self-update
-
       - name: Install dependencies
         run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: ffi
+          extensions: curl, ffi
           ini-values: opcache.jit_buffer_size=256M, opcache.jit=1235, pcre.jit=1
           tools: composer:v2
           coverage: none

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
           phpts: ${{ matrix.zts }}
 
       - name: Install dependencies
-        run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
+        run: composer update --prefer-dist --no-interaction --no-progress
 
       - name: Execute tests
         run: vendor/bin/phpunit --verbose

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,18 +28,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Cache dependencies
-        uses: actions/cache@v1
-        with:
-          path: ~/.composer/cache/files
-          key: dependencies-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
-
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
           extensions: ffi
           ini-values: opcache.jit_buffer_size=256M, opcache.jit=1235, pcre.jit=1
+          tools: composer:v2
           coverage: none
         env:
           phpts: ${{ matrix.zts }}


### PR DESCRIPTION
Slower to cache using github than not to, when using composer 2. Self-update should certainly never be used. The PHP actions project already knows how to specify composer versions. Composer was failing before due to undefined stability.