### PR TITLE
Don't allow PHP 9+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": ">=7.4",
+        "php": "^7.4|^8.0",
         "ext-ffi": "*"
     },
     "require-dev": {


### PR DESCRIPTION
Almost certainly opis won't work on PHP 9, especially the FFI headers!