### PR TITLE
Make new version compatible

### DIFF
--- a/src/CodeWrapper.php
+++ b/src/CodeWrapper.php
@@ -58,7 +58,7 @@ final class CodeWrapper
      */
     public function value(): string
     {
-        return $this->value;
+        return '<?php return ' . $this->value . ';';
     }
 
     /**

--- a/src/ReflectionFunctionInfo.php
+++ b/src/ReflectionFunctionInfo.php
@@ -77,21 +77,17 @@ final class ReflectionFunctionInfo
             return null;
         }
 
-        $code = $this->code() . ";";
+        $code = $this->code();
 
         if ($this->isStatic) {
-            $code = 'return static ' . $code;
-        } else {
-            $code = 'return ' . $code;
+            $code = 'static ' . $code;
         }
-
-        $code = $this->imports() . $code;
 
         return [
             'static' => $this->isStatic,
             'code' => new CodeWrapper($code),
             'short' => $this->isShort,
-            'use' => $this->use ?: null,
+            'use' => $this->use ?: [],
         ];
     }
 
@@ -165,30 +161,6 @@ final class ReflectionFunctionInfo
 
             return;
         }
-    }
-
-    /**
-     * @returns string
-     */
-    private function imports(): string
-    {
-        $code = "<?php\n";
-
-        $ns = $this->reflector->getNamespaceName();
-
-        if ($ns) {
-            $code .= "namespace {$ns};\n";
-        }
-
-        if (!$this->aliases || !$this->hints) {
-            return $code;
-        }
-
-
-        $code .= self::formatImports($this->aliases, $this->hints, $ns);
-
-
-        return $code;
     }
 
     /**

--- a/src/ReflectionFunctionInfo.php
+++ b/src/ReflectionFunctionInfo.php
@@ -77,15 +77,9 @@ final class ReflectionFunctionInfo
             return null;
         }
 
-        $code = $this->code();
-
-        if ($this->isStatic) {
-            $code = 'static ' . $code;
-        }
-
         return [
             'static' => $this->isStatic,
-            'code' => new CodeWrapper($code),
+            'code' => new CodeWrapper($this->code()),
             'short' => $this->isShort,
             'use' => $this->use ?: [],
         ];
@@ -172,7 +166,7 @@ final class ReflectionFunctionInfo
         $count = $this->count;
         $index = &$this->index;
 
-        $code = '';
+        $code = $this->isStatic ? 'static ' : '';
 
         // Function start
 

--- a/src/SerializableClosureHandler.php
+++ b/src/SerializableClosureHandler.php
@@ -170,7 +170,7 @@ final class SerializableClosureHandler
         if ($dst->func->type === 2) { // user function
             $op_array = $dst->func->op_array;
 
-            $op_array->refcount[0] += 1;
+            $op_array->refcount[0]++;
             if (!FFI::isNull($op_array->static_variables)) {
                 $op_array->static_variables->gc->refcount++;
                 $op_array->static_variables_ptr = FFI::addr($op_array->static_variables);

--- a/tests/ReflectionTest.php
+++ b/tests/ReflectionTest.php
@@ -19,6 +19,7 @@ namespace Opis\Closure\Test;
 
 use Closure;
 use Opis\Closure\ReflectionClosure;
+use Opis\Closure\Test\Stub\Object2;
 use PHPUnit\Framework\TestCase;
 
 // Used for test
@@ -105,4 +106,35 @@ class ReflectionTest extends TestCase
             ],
         ];
     }
+
+    /**
+     * @dataProvider codeClosureProvider()
+     */
+    public function testGetCode(Closure $closure, string $expectedCode): void
+    {
+        $ref = new ReflectionClosure($closure);
+
+        $this->assertEquals($expectedCode, $ref->getCode());
+    }
+
+    public function codeClosureProvider(): array
+    {
+        // @formatter:off
+        return [
+            [
+                fn() => 1,
+                'fn() => 1',
+            ],
+            [
+                fn () =>  1,
+                'fn () =>  1',
+            ],
+            [
+                fn (Stub\Object1 $param): Object2 => new Stub\Object2(),
+                'fn (Stub\Object1 $param): Object2 => new Stub\Object2()',
+            ],
+        ];
+        // @formatter:on
+    }
+
 }

--- a/tests/ReflectionTest.php
+++ b/tests/ReflectionTest.php
@@ -130,6 +130,10 @@ class ReflectionTest extends TestCase
                 'fn () =>  1',
             ],
             [
+                static fn () =>  1,
+                'static fn () =>  1',
+            ],
+            [
                 fn (Stub\Object1 $param): Object2 => new Stub\Object2(),
                 'fn (Stub\Object1 $param): Object2 => new Stub\Object2()',
             ],

--- a/tests/Stub/Object1.php
+++ b/tests/Stub/Object1.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Opis\Closure\Test\Stub;
+
+class Object1
+{
+
+}

--- a/tests/Stub/Object2.php
+++ b/tests/Stub/Object2.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Opis\Closure\Test\Stub;
+
+class Object2
+{
+
+}


### PR DESCRIPTION
# The problem

`ReflectionClosure::getCode()` in `3.x` versions returns `raw function code`, but backward compatibility was broken in `4.x` branch. 
`ReflectionClosure::getCode()` in `4.x` branch now returns `<?php {use statements} raw function code`. 
I've tried to fix this and made a test case for testing compatibility with previous major version.

### Test case

```php
<?php

declare(strict_types=1);

namespace Opis\Closure\Test;

use Opis\Closure\ReflectionClosure;
use PHPUnit\Framework\TestCase;

class CompatibleTest extends TestCase
{
    public function testCompatible()
    {
        $fn = fn (MyInterface $arg): int => 1;
        $ref = new ReflectionClosure($fn);
        $code = $ref->getCode();

        $this->assertEquals('fn (MyInterface $arg): int => 1', $code);
    }
}

```

### Branch `4.x`:
```
1) Opis\Closure\Test\CompatibleTest::testCompatible
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'fn (MyInterface $arg): int => 1'
+'<?php\n
+namespace Opis\Closure\Test;\n
+return fn (MyInterface $arg): int => 1;'

/home/xepozz/PhpstormProjects/closure/tests/CompatibleTest.php:18
```

### Pull request's branch
```
OK (1 test, 1 assertion)
```

### Master branch
```
1) Opis\Closure\Test\CompatibleTest::testCompatible
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'fn (MyInterface $arg): int => 1'
+'fn (\Opis\Closure\Test\MyInterface $arg): int => 1'

/home/xepozz/PhpstormProjects/closure/tests/CompatibleTest.php:15
```

### New problem
As you can see `3.0` versions rightly add the namespace part to class/function/constant name.
For example, see to results of testing run on `master` branch above:
`fn (MyInterface $arg)` => `fn (\Opis\Closure\Test\MyInterface $arg)` and other cases

### My proposal

Merge this branch into `4.x` branch.
Anyone who knows parsing more than I will add this compatible omission.

I've created [issue](https://github.com/opis/closure/issues/68) for fixing the new problem

