### PR TITLE
Fix Problem with non initialization property in 7.4 PHP

### DIFF
--- a/src/SerializableClosure.php
+++ b/src/SerializableClosure.php
@@ -662,7 +662,7 @@ class SerializableClosure implements Serializable
                         continue;
                     }
                     $property->setAccessible(true);
-                    if (PHP_VERSION >= 7.4 && !$property->isInitialized($data)) {
+                    if (PHP_VERSION >= 7.4 && !$property->isInitialized($instance)) {
                         continue;
                     }
                     $value = $property->getValue($instance);

--- a/src/SerializableClosure.php
+++ b/src/SerializableClosure.php
@@ -419,6 +419,9 @@ class SerializableClosure implements Serializable
                         continue;
                     }
                     $property->setAccessible(true);
+                    if (PHP_VERSION >= 7.4 && !$property->isInitialized($instance)) {
+                        continue;
+                    }
                     $value = $property->getValue($instance);
                     if(is_array($value) || is_object($value)){
                         static::wrapClosures($value, $storage);

--- a/tests/ReflectionClosure5Test.php
+++ b/tests/ReflectionClosure5Test.php
@@ -143,4 +143,42 @@ class ReflectionClosure5Test extends \PHPUnit\Framework\TestCase
         $this->assertEquals(40, $c3(4));
         $this->assertEquals(48, $c3(4, 6));
     }
+
+    public function testTypedProperties()
+    {
+        $user = new User();
+        $s = $this->s(function () use ($user) {
+            return true;
+        });
+        $this->assertTrue($s());
+
+        $user = new User();
+        $product = new Product();
+        $product->name = "PC";
+        $user->setProduct($product);
+
+        $u = $this->s(function () use ($user) {
+            return $user->getProduct()->name;
+        });
+
+        $this->assertEquals('PC', $u());
+    }
+}
+
+class Product {
+    public string $name;
+}
+
+class User {
+    protected Product $product;
+
+    public function getProduct(): Product
+    {
+        return $this->product;
+    }
+
+    public function setProduct(Product $product): void
+    {
+        $this->product = $product;
+    }
 }


### PR DESCRIPTION
Fixes #76 

### there's an error with 7.4 when we use non initialized properties:

```

use Opis\Closure\ReflectionClosure;

class Car
{
}

class Something
{
    protected Car $car;
}

$test = new Something();

$serializable = new \Opis\Closure\SerializableClosure(function () use ($test) {
    return $test;
});

$serializable->serialize();

```