### PR TITLE
composer: require ext-tokenizer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
         }
     ],
     "require": {
-        "php": "^5.4 || ^7.0 || ^8.0"
+        "php": "^5.4 || ^7.0 || ^8.0",
+        "ext-tokenizer": "*"
     },
     "require-dev": {
         "jeremeamia/superclosure": "^2.0",


### PR DESCRIPTION
Needed by token_get_all used in ReflectionClosure