### PR TITLE
Test package with next PHP version 8.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        php: ['5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0']
+        php: ['5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
 
     steps:
       - name: Checkout Code
@@ -35,7 +35,7 @@ jobs:
           timeout_minutes: 5
           max_attempts: 5
           command: composer update --no-interaction --no-progress
-        if: "matrix.php != '8.0'"
+        if: matrix.php < 8
 
       - name: Install PHP 8 Dependencies
         uses: nick-invision/retry@v1
@@ -46,7 +46,7 @@ jobs:
             composer require "phpunit/phpunit:^9.3" --no-update
             composer update --no-interaction --no-progress --ignore-platform-req=php
             php -v
-        if: "matrix.php == '8.0'"
+        if: matrix.php >= 8
 
       - name: Execute PHPUnit
         run: vendor/bin/phpunit


### PR DESCRIPTION
PHP 8.1 will deprecate `Serializable` those would be good to be fixed in advance.

Here is the error I get when trying to run with dev-master version of PHP:
```
In SerializableClosure.php line 18:

The Serializable interface is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary)
```

Those method get the raw array instead of string so I need to investigate a bit more to propose a fix.

But first I suggest to add PHP 8.1 to the CI so new BC can be caught sooner.