### PR TITLE
Test package with next PHP version 8.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        php: [7.4, 8.0]
+        php: [7.4, 8.0, 8.1]
         zts: [ts, nts]
         exclude:
           - os: ubuntu-latest


### PR DESCRIPTION
PHP 8.1 will deprecate `Serializable` those would be good to be fixed in advance.

Here is the error I get when trying to run with dev-master version of PHP:
```
In SerializableClosure.php line 18:

The Serializable interface is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary)
```

Those method get the raw array instead of string so I need to investigate a bit more to propose a fix.

But first I suggest to add PHP 8.1 to the CI so new BC can be caught sooner.