### PR TITLE
Add support for named parameters.

### DIFF
--- a/src/ReflectionClosure.php
+++ b/src/ReflectionClosure.php
@@ -601,7 +601,7 @@ class ReflectionClosure extends ReflectionFunction
                                         if(isset($classes[$id_start_ci])){
                                             $id_start = $classes[$id_start_ci];
                                         }
-                                        if($id_start[0] !== '\\'){
+                                        if($id_start[0] !== '\\' && (is_array($token) ? $token[1] : $token) !== ':'){
                                             $id_start = $nsf . '\\' . $id_start;
                                         }
                                     }

--- a/tests/ReflectionClosure6Test.php
+++ b/tests/ReflectionClosure6Test.php
@@ -95,6 +95,23 @@ final class ReflectionClosure6Test extends \PHPUnit\Framework\TestCase
         $this->assertEquals('protected', $object->getProtected());
         $this->assertEquals('private', $object->getPrivate());
     }
+
+    public function testClosureUseNamedParameters()
+    {
+        $f = function (string $name) {
+            return sprintf("Hello, %s", $name);
+        };
+
+        $g = function () use ($f) {
+            return $f(name: 'Foo');
+        };
+
+        $res = new SerializableClosure($g);
+        $res = unserialize(serialize($res));
+
+        $this->assertEquals('Hello, Foo', $res());
+    }
+
 }
 
 class PropertyPromotion


### PR DESCRIPTION
So the problem with named parameters is that right now it generates like
this:
```
function () {
    \hello(\name: 'Foo');
}
```
But there should be no `\` in front of named parameter.

Fix is: I check if token is column, then no need to put namespace and `\` in front of named parameter.

Fixes #90 