### PR TITLE
Do not register wrapper if already registered

### DIFF
--- a/src/ClosureStream.php
+++ b/src/ClosureStream.php
@@ -91,7 +91,7 @@ class ClosureStream
 
     public static function register()
     {
-        if (!static::$isRegistered) {
+        if (!static::$isRegistered && ! in_array(static::STREAM_PROTO, stream_get_wrappers())) {
             static::$isRegistered = stream_wrapper_register(static::STREAM_PROTO, __CLASS__);
         }
     }


### PR DESCRIPTION
Version: 3.6.2

Laravel 8.62.0 added a new dependency and also registers the same wrapper but their code fortunately has a backup check to see if it has already been registered in `stream_get_wrappers()`, it would br great if this package did that check to so I can fix the below error I am getting in my application.

https://github.com/laravel/serializable-closure/blob/master/src/Support/ClosureStream.php#L172-L177

![image](https://user-images.githubusercontent.com/20278756/135858913-8e98df53-9471-4b8e-ace1-4eb945b1626a.png)
