### PR TITLE
Fix serialization of DateTime object not working since php 7.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
     },
     "require-dev": {
         "jeremeamia/superclosure": "^2.0",
+        "nesbot/carbon": "*",
         "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
     },
     "autoload": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -37,5 +37,8 @@
         <testsuite name="ReflectionClosure6">
             <file phpVersion="8.0.0-dev" phpVersionOperator=">=">./tests/ReflectionClosure6Test.php</file>
         </testsuite>
+        <testsuite name="DateTimeReflection">
+            <file phpVersion="7.1.0" phpVersionOperator=">=">./tests/DateTimeReflectionTest.php</file>
+        </testsuite>
     </testsuites>
 </phpunit>

--- a/src/SerializableClosure.php
+++ b/src/SerializableClosure.php
@@ -398,6 +398,18 @@ class SerializableClosure implements Serializable
             }
             unset($value);
         } elseif (is_object($data) && ! $data instanceof static){
+
+            // Starting at PHP 7.4 there is a bug that prevents the use of
+            // the ReflectionObject with a DateTime object, as the getProperties() method
+            // returns an empty array.
+            // @see https://bugs.php.net/bug.php?id=79041
+            // @see https://3v4l.org/joLur
+            // For this reason and to avoid any issues, we can just skip the wrapping
+            // of DateTime objects.
+            if (PHP_VERSION >= 7.4 && $data instanceof \DateTime) {
+                return;
+            }
+
             if(isset($storage[$data])){
                 $data = $storage[$data];
                 return;

--- a/src/SerializableClosure.php
+++ b/src/SerializableClosure.php
@@ -406,8 +406,11 @@ class SerializableClosure implements Serializable
             // @see https://3v4l.org/joLur
             // For this reason and to avoid any issues, we can just skip the wrapping
             // of DateTime objects.
-            if (PHP_VERSION >= 7.4 && $data instanceof \DateTime) {
-                return;
+            if (PHP_VERSION >= 7.1) {
+                // Cannot do this if statement one line as DateTime is only available since PHP 7.1
+                if ($data instanceof \DateTime) {
+                    return;
+                }
             }
 
             if(isset($storage[$data])){

--- a/tests/DateTimeReflectionTest.php
+++ b/tests/DateTimeReflectionTest.php
@@ -1,0 +1,70 @@
+<?php
+/* ===========================================================================
+ * Copyright (c) 2018-2021 Zindex Software
+ *
+ * Licensed under the MIT License
+ * =========================================================================== */
+
+namespace Opis\Closure\Test;
+
+class DateTimeReflectionTest extends \PHPUnit\Framework\TestCase
+{
+	public function testDateTime()
+	{
+
+		$a = new \DateTime('NOW');
+		$b = \Opis\Closure\unserialize(\Opis\Closure\serialize($a));
+		$this->assertEquals($a, $b);
+	}
+
+	public function testDateTime2()
+	{
+		$a = [
+			'foo' => new \DateTime('NOW'),
+			'bar' => function () {
+				return 'bar';
+			},
+			'baz' => 'baz'
+		];
+		$b = \Opis\Closure\unserialize(\Opis\Closure\serialize($a));
+		$this->assertEquals($a, $b);
+	}
+
+	public function testDateTime3()
+	{
+		$a =  function () {
+			return new \DateTime('NOW');
+		};
+		$b = \Opis\Closure\unserialize(\Opis\Closure\serialize($a));
+		$this->assertEquals($a, $b);
+	}
+
+	public function testCarbon()
+	{
+		$a = \Carbon\Carbon::now();
+		$b = \Opis\Closure\unserialize(\Opis\Closure\serialize($a));
+		$this->assertEquals($a, $b);
+	}
+
+	public function testCarbon2()
+	{
+		$a = [
+			'foo' => \Carbon\Carbon::now(),
+			'bar' => function () {
+				return 'bar';
+			},
+			'baz' => 'baz'
+		];
+		$b = \Opis\Closure\unserialize(\Opis\Closure\serialize($a));
+		$this->assertEquals($a, $b);
+	}
+
+	public function testCarbon3()
+	{
+		$a =  function () {
+			return \Carbon\Carbon::now();
+		};
+		$b = \Opis\Closure\unserialize(\Opis\Closure\serialize($a));
+		$this->assertEquals($a, $b);
+	}
+}


### PR DESCRIPTION
Starting at PHP 7.4 there is a bug that prevents the use of the ReflectionObject with a DateTime object, as the getProperties() method returns an empty array.


@see https://bugs.php.net/bug.php?id=79041
@see https://3v4l.org/joLur

For this reason and to avoid any issues, we can just skip the wrapping of DateTime objects.

Related issue : #75 

@sorinsarca I hope this is OK to merge and release. I tested it locally and seems to work just fine. Also I guess this will be no issue anymore with the v4 that is in the works, but for now as I use this with Laravel, I cannot upgrade to the v4 so I would need this workaround.