### PR TITLE
native enum support on version 3

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        php: ['5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0']
+        php: ['5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0','8.1']
 
     steps:
       - name: Checkout Code
@@ -46,7 +46,7 @@ jobs:
             composer require "phpunit/phpunit:^9.3" --no-update
             composer update --no-interaction --no-progress --ignore-platform-req=php
             php -v
-        if: "matrix.php == '8.0'"
+        if: "matrix.php == '8.0' || matrix.php == '8.1'"
 
       - name: Execute PHPUnit
         run: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^5.4 || ^7.0 || ^8.0"
+        "php": "^5.4 || ^7.0 || ^8.0 || ^8.1"
     },
     "require-dev": {
         "jeremeamia/superclosure": "^2.0",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -37,5 +37,8 @@
         <testsuite name="ReflectionClosure6">
             <file phpVersion="8.0.0-dev" phpVersionOperator=">=">./tests/ReflectionClosure6Test.php</file>
         </testsuite>
+        <testsuite name="EnumTest">
+            <file phpVersion="8.1.0" phpVersionOperator=">=">./tests/EnumTest.php</file>
+        </testsuite>
     </testsuites>
 </phpunit>

--- a/src/SerializableClosure.php
+++ b/src/SerializableClosure.php
@@ -387,6 +387,8 @@ class SerializableClosure implements Serializable
             }
             unset($value);
             unset($data[self::ARRAY_RECURSIVE_KEY]);
+        } elseif(interface_exists('UnitEnum') && is_object($data) && is_subclass_of($data, 'UnitEnum')){
+            return;
         } elseif($data instanceof \stdClass){
             if(isset($storage[$data])){
                 $data = $storage[$data];
@@ -627,6 +629,8 @@ class SerializableClosure implements Serializable
             }
             unset($value);
             unset($data[self::ARRAY_RECURSIVE_KEY]);
+        } elseif(interface_exists('UnitEnum') && is_object($data) && is_subclass_of($data, 'UnitEnum')){
+            return;
         } elseif ($data instanceof \stdClass) {
             if(isset($this->scope[$data])){
                 $data = $this->scope[$data];

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Opis\Closure\Test;
+
+use Closure;
+use Opis\Closure\SerializableClosure;
+use Opis\Closure\Test\Fixtures\TestUnitEnum;
+use Opis\Closure\Test\Fixtures\TestBackedEnum;
+
+final class EnumTest extends \PHPUnit\Framework\TestCase
+{
+    public function testSerializesUnitEnum()
+    {
+        $enum = TestUnitEnum::Test;
+
+        $closure = function () use ($enum) {
+            $this->assertEquals(TestUnitEnum::Test, $enum);
+        };
+
+        $executable = $this->s($closure);
+
+        $executable();
+    }
+
+    public function testSerializesBackedEnum()
+    {
+        $enum = TestBackedEnum::Test;
+
+        $closure = function () use ($enum) {
+            $this->assertEquals(TestBackedEnum::Test, $enum);
+        };
+
+        $executable = $this->s($closure);
+
+        $executable();
+    }
+
+    public function testSerializesUnitEnumUsingFunctions()
+    {
+        $expected = TestUnitEnum::Test;
+
+        $actual = \Opis\Closure\unserialize(\Opis\Closure\serialize($expected));
+
+        $this->assertEquals($expected, $actual);
+
+    }
+
+    public function testSerializesBackedEnumUsingFunctions()
+    {
+        $expected = TestBackedEnum::Test;
+
+        $actual = \Opis\Closure\unserialize(\Opis\Closure\serialize($expected));
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    protected function s($closure)
+    {
+        if ($closure instanceof Closure) {
+            $closure = new SerializableClosure($closure);
+        }
+
+        return unserialize(serialize($closure))->getClosure();
+    }
+}

--- a/tests/Fixtures/TestBackedEnum.php
+++ b/tests/Fixtures/TestBackedEnum.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Opis\Closure\Test\Fixtures;
+
+enum TestBackedEnum: string
+{
+    case Test = 'test';
+}

--- a/tests/Fixtures/TestUnitEnum.php
+++ b/tests/Fixtures/TestUnitEnum.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Opis\Closure\Test\Fixtures;
+
+enum TestUnitEnum
+{
+    case Test;
+}


### PR DESCRIPTION
I know version 4 is supporting 8.1 and may support enums. But it is still not yet released while php 8.1 was released in November last year.

This PR will support native enums, without breaking functionality in older PHP versions.