### PR TITLE
Support phpunit 10 and fix PSR-4 warnings found by phpunit 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "require-dev": {
         "jeremeamia/superclosure": "^2.0",
-        "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+        "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10"
     },
     "autoload": {
         "psr-4": {

--- a/tests/NamespaceFullyQualifiedTest.php
+++ b/tests/NamespaceFullyQualifiedTest.php
@@ -5,7 +5,7 @@ namespace Opis\Closure\Test;
 use Closure;
 use Opis\Closure\ReflectionClosure;
 
-final class NamespaceGroupTest extends \PHPUnit\Framework\TestCase
+final class NamespaceFullyQualifiedTest extends \PHPUnit\Framework\TestCase
 {
     public function test_namespace_fully_qualified()
     {

--- a/tests/NamespaceGroupTest.php
+++ b/tests/NamespaceGroupTest.php
@@ -9,7 +9,7 @@ use Foo\{
     Baz\Qux\Forest
 };
 
-final class NamespaceFullyQualifiedTest extends \PHPUnit\Framework\TestCase
+final class NamespaceGroupTest extends \PHPUnit\Framework\TestCase
 {
     public function test_namespace_fully_qualified()
     {


### PR DESCRIPTION
Fixes

```
There were 2 PHPUnit test runner warnings:

1) Class NamespaceFullyQualifiedTest cannot be found in /mnt/Dev/@williamdes/@forked-repos/closure/tests/NamespaceFullyQualifiedTest.php

2) Class NamespaceGroupTest cannot be found in /mnt/Dev/@williamdes/@forked-repos/closure/tests/NamespaceGroupTest.php
```

Found after allowing phpunit 10