### PR TITLE
Fixes for PHP 8.4 compatibility

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -29,7 +29,7 @@ function serialize($data)
  * @param array|null $options
  * @return mixed
  */
-function unserialize($data, array $options = null)
+function unserialize($data, ?array $options = null)
 {
     SerializableClosure::enterContext();
     $data = ($options === null || \PHP_MAJOR_VERSION < 7)


### PR DESCRIPTION
Fixes for PHP 8.4 compatibility.

On updating to PHP8.4, we started getting below deprecation error 
```
Deprecated: Opis\Closure\unserialize(): Implicitly marking parameter $options as nullable is deprecated, the explicit nullable type must be used instead in /home/runner/work/plugin-ActivityLog/plugin-ActivityLog/matomo/vendor/opis/closure/functions.php on line 32
```

The PR aims to fix this issue