### PR TITLE
Implement fix for deprecation warning in PHP 8.4

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -29,7 +29,7 @@ function serialize($data)
  * @param array|null $options
  * @return mixed
  */
-function unserialize($data, array $options = null)
+function unserialize($data, ?array $options = null)
 {
     SerializableClosure::enterContext();
     $data = ($options === null || \PHP_MAJOR_VERSION < 7)


### PR DESCRIPTION
Fix the following deprecation warning with PHP 8.4:

    Deprecated: Opis\Closure\unserialize(): Implicitly marking parameter $options as nullable is deprecated, the explicit nullable type must be used instead