### PR TITLE
Fix PHP 8.4 deprecation

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -29,7 +29,7 @@ function serialize($data)
  * @param array|null $options
  * @return mixed
  */
-function unserialize($data, array $options = null)
+function unserialize($data, ?array $options = null)
 {
     SerializableClosure::enterContext();
     $data = ($options === null || \PHP_MAJOR_VERSION < 7)


### PR DESCRIPTION
Fixes following PHP 8.4 deprecation for v3:
```
Deprecated: Opis\Closure\unserialize(): Implicitly marking parameter $options as nullable is deprecated, the explicit nullable type must be used instead in /srv/vendor/opis/closure/functions.php on line 32
```