### PR TITLE
Make PHP 5.6 hapy with latest 8.4 changes

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -29,7 +29,7 @@ function serialize($data)
  * @param array|null $options
  * @return mixed
  */
-function unserialize($data, ?array $options = null)
+function unserialize($data, $options = null)
 {
     SerializableClosure::enterContext();
     $data = ($options === null || \PHP_MAJOR_VERSION < 7)


### PR DESCRIPTION
Make https://github.com/opis/closure/pull/157 compatible with PHP 5.6